### PR TITLE
Melhorar suporte ARM no instalador e perfis opcionais

### DIFF
--- a/bitcoin_mining_automation/GUIA_EXECUCAO_RASPBERRY_PI_UBUNTU.md
+++ b/bitcoin_mining_automation/GUIA_EXECUCAO_RASPBERRY_PI_UBUNTU.md
@@ -143,10 +143,14 @@ asics:
 cd /opt/bitcoin_mining
 
 # Iniciar com Docker
-docker-compose up -d
+docker compose up -d
 
 # Verificar status
-docker-compose ps
+docker compose ps
+
+# (Opcional) Habilitar serviços adicionais
+# docker compose --profile ollama up -d    # Requer imagem amd64 do Ollama
+# docker compose --profile frontend up -d  # Disponível após adicionar o código do frontend
 ```
 
 #### 4.2 Opção B: Python Direto

--- a/bitcoin_mining_automation/README.md
+++ b/bitcoin_mining_automation/README.md
@@ -57,7 +57,7 @@ nano config/devices.yaml
 ### 3. Iniciar Sistema
 ```bash
 # Opção A: Docker (Recomendado)
-docker-compose up -d
+docker compose up -d
 
 # Opção B: Python direto
 source .venv/bin/activate
@@ -65,6 +65,15 @@ python main.py
 
 # Opção C: Serviço do sistema
 sudo systemctl start bitcoin-mining-python.service
+```
+
+```bash
+# Verificar status
+docker compose ps
+
+# (Opcional) Habilitar serviços adicionais
+# docker compose --profile ollama up -d    # Requer imagem amd64
+# docker compose --profile frontend up -d  # Disponível após adicionar o código do frontend
 ```
 
 ## 🔧 Comandos Úteis
@@ -91,7 +100,7 @@ python scripts/test_raspberry_pi.py  # Testar sistema (Raspberry Pi)
 ## 🌐 Interfaces Disponíveis
 
 - **API**: http://seu-ip:8000
-- **Frontend**: http://seu-ip:3000
+- **Frontend** (opcional): http://seu-ip:3000
 - **Grafana**: http://seu-ip:3001
 - **Prometheus**: http://seu-ip:9090
 - **RabbitMQ**: http://seu-ip:15672
@@ -106,6 +115,9 @@ python scripts/test_raspberry_pi.py  # Testar sistema (Raspberry Pi)
 - [install_linux.sh](install_linux.sh) - Instalação universal para Linux
 - [scripts/install_ubuntu_raspberry_pi.sh](scripts/install_ubuntu_raspberry_pi.sh) - Raspberry Pi com Ubuntu
 - [scripts/install_raspberry_pi_enhanced.sh](scripts/install_raspberry_pi_enhanced.sh) - Raspberry Pi com Raspbian
+
+### Dependências Opcionais
+- [backend/requirements-ml.txt](backend/requirements-ml.txt) - Pacotes extras para pipelines de IA locais
 
 ### Scripts de Inicialização
 - [quick_start_linux.sh](quick_start_linux.sh) - Inicialização rápida Linux

--- a/bitcoin_mining_automation/backend/core/config.py
+++ b/bitcoin_mining_automation/backend/core/config.py
@@ -24,10 +24,10 @@ class Config(BaseSettings):
     rabbitmq_url: str = Field(default="amqp://localhost:5672", env="RABBITMQ_URL")
     
     # Configurações de LLM
-    llm_mode: str = Field(default="local", env="LLM_MODE")  # local ou remote
+    llm_mode: str = Field(default="disabled", env="LLM_MODE")  # disabled, local ou remote
     openai_api_key: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
     anthropic_api_key: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
-    llm_endpoint: str = Field(default="http://localhost:11434", env="LLM_ENDPOINT")
+    llm_endpoint: Optional[str] = Field(default="http://localhost:11434", env="LLM_ENDPOINT")
     
     # Configurações de dispositivos
     abb_host: str = Field(default="192.168.0.10", env="ABB_HOST")
@@ -163,9 +163,11 @@ class Config(BaseSettings):
     
     def is_llm_configured(self) -> bool:
         """Verificar se LLM está configurado"""
+        if self.llm_mode == "disabled":
+            return False
         if self.llm_mode == "local":
-            return True
-        elif self.llm_mode == "remote":
+            return bool(self.llm_endpoint)
+        if self.llm_mode == "remote":
             return bool(self.openai_api_key or self.anthropic_api_key)
         return False
     
@@ -203,7 +205,7 @@ class Config(BaseSettings):
             errors.append("REDIS_URL deve ser uma URL válida do Redis")
         
         # Validar configurações de LLM
-        if not self.is_llm_configured():
+        if self.llm_mode != "disabled" and not self.is_llm_configured():
             errors.append("LLM não está configurado corretamente")
         
         # Validar thresholds

--- a/bitcoin_mining_automation/backend/requirements-ml.txt
+++ b/bitcoin_mining_automation/backend/requirements-ml.txt
@@ -1,0 +1,9 @@
+# Requisitos opcionais para recursos de IA avançados
+# Instale apenas se precisar executar modelos locais ou pipelines que dependem de PyTorch/Transformers.
+
+# Torch possui wheels específicos por arquitetura. Consulte https://pytorch.org/get-started/locally/
+# e ajuste o --index-url conforme a plataforma (por exemplo, aarch64 CPU somente).
+# Exemplo para ARM64 CPU: pip install --index-url https://download.pytorch.org/whl/cpu torch==2.1.1
+
+torch==2.1.1
+transformers==4.36.2

--- a/bitcoin_mining_automation/backend/requirements.txt
+++ b/bitcoin_mining_automation/backend/requirements.txt
@@ -24,11 +24,9 @@ pymodbus==3.5.2
 # ASIC Control
 hashcore-toolkit==1.0.0
 
-# Machine Learning & AI
+# Machine Learning & AI (instalação básica)
 openai==1.3.7
 anthropic==0.7.8
-transformers==4.36.2
-torch==2.1.1
 scikit-learn==1.3.2
 numpy==1.24.4
 pandas==2.1.4

--- a/bitcoin_mining_automation/docker-compose.yml
+++ b/bitcoin_mining_automation/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - DATABASE_URL=postgresql://bitcoin_mining:password@postgres:5432/bitcoin_mining
       - REDIS_URL=redis://redis:6379
       - RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672
-      - LLM_MODE=local
-      - LLM_ENDPOINT=http://ollama:11434
+      - LLM_MODE=${LLM_MODE:-disabled}
+      - LLM_ENDPOINT=${LLM_ENDPOINT:-http://ollama:11434}
       - ABB_HOST=192.168.0.10
       - ABB_PORT=502
       - BLE_INTERFACE=/dev/ttyUSB0
@@ -120,7 +120,7 @@ services:
     networks:
       - bitcoin_mining_network
 
-  # Ollama para LLM local
+  # Ollama para LLM local (opcional, apenas amd64)
   ollama:
     image: ollama/ollama:latest
     container_name: bitcoin_mining_ollama
@@ -133,6 +133,8 @@ services:
     restart: unless-stopped
     networks:
       - bitcoin_mining_network
+    profiles:
+      - ollama
 
   # Nginx para proxy reverso
   nginx:
@@ -166,6 +168,8 @@ services:
     restart: unless-stopped
     networks:
       - bitcoin_mining_network
+    profiles:
+      - frontend
 
 volumes:
   postgres_data:

--- a/bitcoin_mining_automation/env.example
+++ b/bitcoin_mining_automation/env.example
@@ -27,8 +27,8 @@ RABBITMQ_URL=amqp://guest:guest@localhost:5672
 # =============================================================================
 # LLM (LARGE LANGUAGE MODEL)
 # =============================================================================
-# Modo: local ou remote
-LLM_MODE=local
+# Modo: disabled, local ou remote
+LLM_MODE=disabled
 
 # Para modo local (Ollama)
 LLM_ENDPOINT=http://localhost:11434

--- a/bitcoin_mining_automation/frontend/Dockerfile
+++ b/bitcoin_mining_automation/frontend/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+
+COPY public /usr/share/nginx/html
+
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:80 || exit 1

--- a/bitcoin_mining_automation/frontend/public/index.html
+++ b/bitcoin_mining_automation/frontend/public/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bitcoin Mining Automation - Placeholder</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        margin: 0;
+      }
+      .card {
+        background: rgba(15, 23, 42, 0.8);
+        padding: 2.5rem;
+        border-radius: 1rem;
+        max-width: 28rem;
+        text-align: center;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+      }
+      h1 {
+        margin-bottom: 1rem;
+        font-size: 1.75rem;
+      }
+      p {
+        line-height: 1.6;
+        font-size: 1rem;
+      }
+      code {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.5rem 0.75rem;
+        background: rgba(30, 41, 59, 0.9);
+        border-radius: 0.5rem;
+        font-size: 0.95rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Interface Web em Preparação</h1>
+      <p>
+        O perfil <strong>frontend</strong> está ativo, mas o projeto React/Vue ainda não foi
+        adicionado. Utilize esta imagem estática como placeholder ou substitua o conteúdo
+        da pasta <code>frontend/</code> por sua implementação.
+      </p>
+      <p>
+        Para desativar este container execute:
+      </p>
+      <code>docker compose stop frontend</code>
+    </div>
+  </body>
+</html>

--- a/bitcoin_mining_automation/install_linux.sh
+++ b/bitcoin_mining_automation/install_linux.sh
@@ -76,7 +76,16 @@ detect_arch() {
 detect_distro
 detect_arch
 
+DISTRO_CODENAME=""
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    DISTRO_CODENAME=${VERSION_CODENAME:-$UBUNTU_CODENAME}
+fi
+
 log "Distribuição detectada: $DISTRO $VERSION"
+if [ -n "$DISTRO_CODENAME" ]; then
+    log "Codinome detectado: $DISTRO_CODENAME"
+fi
 log "Arquitetura detectada: $ARCH"
 
 # Verificar se a distribuição é suportada
@@ -381,8 +390,15 @@ install_nodejs() {
     
     case $DISTRO in
         ubuntu|debian)
-            curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-            apt-get install -y nodejs
+            NODE_MAJOR=20
+            if [ -n "$DISTRO_CODENAME" ] && curl -fsI "https://deb.nodesource.com/node_${NODE_MAJOR}.x/dists/${DISTRO_CODENAME}/Release" >/dev/null 2>&1; then
+                log "Distribuição suportada pela NodeSource. Instalando Node.js ${NODE_MAJOR}.x"
+                curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+                apt-get install -y nodejs
+            else
+                warn "NodeSource não suporta ${DISTRO_CODENAME:-esta distribuição} na série ${NODE_MAJOR}.x. Instalando nodejs/npm do repositório padrão"
+                apt-get install -y nodejs npm
+            fi
             ;;
         centos|rhel|fedora)
             curl -fsSL https://rpm.nodesource.com/setup_18.x | bash -
@@ -394,7 +410,11 @@ install_nodejs() {
     esac
     
     # Instalar Yarn
-    npm install -g yarn
+    if command -v npm &> /dev/null; then
+        npm install -g yarn
+    else
+        warn "npm não encontrado; Yarn não será instalado automaticamente"
+    fi
 }
 
 # Criar diretórios

--- a/bitcoin_mining_automation/nginx/nginx.conf
+++ b/bitcoin_mining_automation/nginx/nginx.conf
@@ -1,0 +1,39 @@
+user  nginx;
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+    error_log   /var/log/nginx/error.log warn;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream backend_app {
+        server app:8000;
+    }
+
+    server {
+        listen       80;
+        server_name  _;
+
+        location / {
+            proxy_pass         http://backend_app;
+            proxy_http_version 1.1;
+            proxy_set_header   Upgrade $http_upgrade;
+            proxy_set_header   Connection 'upgrade';
+            proxy_set_header   Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+    }
+}

--- a/bitcoin_mining_automation/scripts/install_ubuntu_raspberry_pi.sh
+++ b/bitcoin_mining_automation/scripts/install_ubuntu_raspberry_pi.sh
@@ -49,7 +49,8 @@ fi
 
 # Verificar versão do Ubuntu
 UBUNTU_VERSION=$(lsb_release -rs)
-log "Versão do Ubuntu detectada: $UBUNTU_VERSION"
+UBUNTU_CODENAME=$(lsb_release -cs)
+log "Versão do Ubuntu detectada: $UBUNTU_VERSION ($UBUNTU_CODENAME)"
 
 if [[ "$UBUNTU_VERSION" < "20.04" ]]; then
     error "Ubuntu 20.04+ é necessário. Versão atual: $UBUNTU_VERSION"
@@ -261,11 +262,27 @@ docker-compose --version
 
 # Instalar Node.js (para frontend)
 log "Instalando Node.js..."
-curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-apt-get install -y nodejs
+if command -v node &> /dev/null; then
+    log "Node.js já instalado (versão $(node --version))"
+else
+    NODE_MAJOR=20
+    NODESOURCE_RELEASE_URL="https://deb.nodesource.com/node_${NODE_MAJOR}.x/dists/${UBUNTU_CODENAME}/Release"
+    if curl -fsI "$NODESOURCE_RELEASE_URL" >/dev/null 2>&1; then
+        log "Distribuição suportada pela NodeSource. Instalando Node.js ${NODE_MAJOR}.x via repositório oficial"
+        curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+        apt-get install -y nodejs
+    else
+        warn "NodeSource ainda não suporta o codinome ${UBUNTU_CODENAME}. Utilizando pacotes do Ubuntu"
+        apt-get install -y nodejs npm
+    fi
+fi
 
-# Instalar Yarn
-npm install -g yarn
+# Instalar Yarn (se npm estiver disponível)
+if command -v npm &> /dev/null; then
+    npm install -g yarn
+else
+    warn "npm não encontrado; Yarn não será instalado automaticamente"
+fi
 
 # Criar diretórios
 log "Criando diretórios..."

--- a/docs/UBUNTU_ARM_COMPATIBILITY.md
+++ b/docs/UBUNTU_ARM_COMPATIBILITY.md
@@ -1,0 +1,96 @@
+# Revisão e Compatibilidade com Ubuntu ARM
+
+## Visão Geral do Repositório
+
+O projeto principal está no diretório `bitcoin_mining_automation/` e fornece um backend em FastAPI, scripts de instalação e monitoramento, além de orquestração via Docker Compose para a automação de uma infraestrutura de mineração de Bitcoin. A arquitetura técnica detalha a integração entre backend, coleta de dados (ABB, ASICs, BLE), notificações e monitoramento com Prometheus/Grafana.【F:bitcoin_mining_automation/docs/TECHNICAL_ARCHITECTURE.md†L1-L88】
+
+Os scripts `install_linux.sh` e `quick_start_linux.sh` tratam da instalação universal em distribuições Linux e incluem suporte explícito a arquiteturas ARM (ARM64/ARMHF).【F:bitcoin_mining_automation/install_linux.sh†L9-L92】【F:bitcoin_mining_automation/quick_start_linux.sh†L1-L88】 Há, ainda, um script específico para Raspberry Pi com Ubuntu (`scripts/install_ubuntu_raspberry_pi.sh`) que automatiza a preparação da plataforma ARM, cobrindo dependências de Modbus, BLE e bibliotecas Python, além de ajustes relacionados ao HashCore Toolkit.【F:bitcoin_mining_automation/scripts/install_ubuntu_raspberry_pi.sh†L1-L214】【F:bitcoin_mining_automation/scripts/install_ubuntu_raspberry_pi.sh†L300-L372】
+
+## Avaliação de Compatibilidade Ubuntu ARM
+
+1. **Scripts de instalação** – O script dedicado ao Ubuntu em ARM verifica a arquitetura (`aarch64`/`armv7l`), instala dependências via `apt` (incluindo bibliotecas Modbus/BLE) e agora detecta automaticamente se o repositório da NodeSource suporta o codinome do Ubuntu, adotando o pacote nativo quando necessário. Isso confirma suporte direto a Ubuntu ARM a partir da versão 20.04.【F:bitcoin_mining_automation/scripts/install_ubuntu_raspberry_pi.sh†L25-L214】【F:bitcoin_mining_automation/scripts/install_ubuntu_raspberry_pi.sh†L215-L252】
+2. **Backend/Docker** – O backend usa base `python:3.11-slim`, disponível em ARM, e instala bibliotecas Python compatíveis. O `docker-compose.yml` define `LLM_MODE` como desabilitado por padrão e expõe o serviço Ollama atrás de um profile opcional, evitando a tentativa de baixar imagens somente `amd64` em ARM.【F:bitcoin_mining_automation/docker-compose.yml†L7-L118】
+3. **Frontend opcional** – O `docker-compose.yml` coloca o serviço `frontend` sob um profile específico. Assim, a execução padrão (`docker compose up`) funciona sem depender de um diretório inexistente, mantendo a possibilidade de habilitar o componente quando o código estiver disponível.【F:bitcoin_mining_automation/docker-compose.yml†L119-L146】
+4. **HashCore Toolkit** – O backend e os scripts esperam o binário `hashcore` em `/usr/local/bin`. O guia de execução para Ubuntu ARM fornece um pacote `.deb` específico (`hashcore-toolkit_1.0.0_arm64.deb`); se o pacote não estiver disponível para a arquitetura utilizada, deve-se instalar via `pip install hashcore-toolkit`, sujeito à disponibilidade de wheels ARM.【F:bitcoin_mining_automation/GUIA_EXECUCAO_RASPBERRY_PI_UBUNTU.md†L249-L320】【F:bitcoin_mining_automation/backend/core/data_collectors/asic_collector.py†L28-L336】
+5. **Dependências externas** – Os serviços PostgreSQL, Redis, RabbitMQ, Prometheus e Grafana utilizam imagens multi-arquitetura. Em Ubuntu ARM, o `docker compose` puxa as variantes ARM automaticamente, mantendo Ollama e o frontend como opt-in.【F:bitcoin_mining_automation/docker-compose.yml†L19-L146】
+6. **Bibliotecas de IA** – As dependências pesadas (`torch`/`transformers`) foram movidas para um arquivo opcional (`backend/requirements-ml.txt`), evitando falhas de build em ARM quando esses componentes não são necessários.【F:bitcoin_mining_automation/backend/requirements.txt†L1-L53】【F:bitcoin_mining_automation/backend/requirements-ml.txt†L1-L9】
+
+### Conclusão de Compatibilidade
+
+- ✅ **Ubuntu ARM 20.04+ é suportado** pelos scripts e documentação do repositório.  
+- ⚠️ **Serviço Ollama** continua opcional; habilite apenas se houver suporte à arquitetura e imagem disponível.
+- ⚠️ **Serviço frontend** permanece opcional; forneça o código antes de habilitar o profile correspondente.
+- ⚠️ **HashCore Toolkit** requer verificação manual para garantir a disponibilidade de pacotes/wheels ARM.  
+
+## Passo a Passo para Instalação no Ubuntu ARM
+
+A sequência abaixo pressupõe um Ubuntu ARM recém-instalado (por exemplo, Raspberry Pi 4 com Ubuntu Server 24.04) e acesso ao terminal com usuário com privilégios `sudo`.
+
+```bash
+# 1. Atualizar o sistema
+sudo apt update && sudo apt upgrade -y
+
+# 2. Instalar dependências básicas
+sudo apt install -y curl wget git vim htop tree unzip \
+    software-properties-common apt-transport-https ca-certificates gnupg lsb-release \
+    build-essential cmake pkg-config python3 python3-dev python3-pip python3-venv \
+    python3-tk python3-pil python3-pil.imagetk libmodbus-dev libffi-dev libssl-dev \
+    bluez bluez-tools bluetooth
+
+# 3. (Opcional) Configurar Python 3.11+ caso a versão padrão seja antiga
+sudo add-apt-repository ppa:deadsnakes/ppa -y
+sudo apt update
+sudo apt install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+
+# 4. Clonar o repositório
+cd /opt
+sudo git clone https://github.com/seu-usuario/bitcoin-mining-automation.git
+sudo chown -R $USER:$USER bitcoin-mining-automation
+cd bitcoin-mining-automation
+
+# 5. Copiar variáveis de ambiente e configurar
+cp .env.example .env
+nano .env
+
+# 6. Ajustar configuração de dispositivos
+mkdir -p config
+nano config/devices.yaml
+
+# 7. (Opcional) Instalar HashCore Toolkit para ARM64
+wget https://releases.hashcore.io/hashcore-toolkit_1.0.0_arm64.deb
+sudo dpkg -i hashcore-toolkit_1.0.0_arm64.deb || sudo apt -f install -y
+# ou, se indisponível:
+# pip install hashcore-toolkit
+
+# 8. Instalar e habilitar Docker (necessário para stack completa)
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker $USER
+newgrp docker
+sudo systemctl enable docker
+
+# 9. Instalar Docker Compose plugin
+sudo apt install -y docker-compose-plugin
+
+# 10. Subir os serviços essenciais
+docker compose up -d
+
+# 11. (Opcional) Habilitar serviços extras
+# docker compose --profile ollama up -d    # Requer imagem amd64 do Ollama
+# docker compose --profile frontend up -d  # Disponível após adicionar o código do frontend
+
+# 12. Verificar status
+docker compose ps
+
+# 13. Acompanhar logs do backend
+docker compose logs -f app
+```
+
+> 💡 Caso o Docker não seja necessário, é possível usar o script `scripts/install_ubuntu_raspberry_pi.sh` para instalar o backend e serviços diretamente no host, conforme descrito no `GUIA_EXECUCAO_RASPBERRY_PI_UBUNTU.md`.
+
+## Recomendações Pós-Instalação
+
+- Configure o firewall para liberar as portas 8000 (API), 3001 (Grafana), 5432 (PostgreSQL) e 6379 (Redis) conforme necessário.【F:bitcoin_mining_automation/GUIA_EXECUCAO_RASPBERRY_PI_UBUNTU.md†L199-L288】  
+- Utilize os scripts de diagnóstico e monitoramento (`diagnose.sh`, `monitor.sh`) para validar o ambiente após a instalação.【F:bitcoin_mining_automation/GUIA_EXECUCAO_RASPBERRY_PI_UBUNTU.md†L129-L197】  
+- Se optar pelo modo sem Docker, ajuste o serviço `bitcoin-mining-python.service` conforme indicado na documentação para inicialização automática.【F:bitcoin_mining_automation/GUIA_EXECUCAO_RASPBERRY_PI_UBUNTU.md†L97-L197】
+


### PR DESCRIPTION
## Summary
- detectar o codinome do Ubuntu nos instaladores e usar fallback de pacotes nativos de Node.js quando o repositório da NodeSource não estiver disponível
- tornar os serviços Ollama e frontend opcionais via profiles no docker-compose, adicionando um placeholder funcional para o frontend e um nginx de proxy reverso
- definir o LLM como desabilitado por padrão, separar requisitos de IA pesados em arquivo opcional e atualizar a documentação de uso no Ubuntu ARM

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72aef845083248612d781f9da6cac